### PR TITLE
Update the name as it is already taken

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "body-parser-bigint",
+  "name": "body-parser-bigint-middleware",
   "description": "Node.js body parsing middleware with bigint support",
   "version": "1.20.2",
   "contributors": [


### PR DESCRIPTION
The repo backed by existing package does not seem to exist: https://www.npmjs.com/package//body-parser-bigint